### PR TITLE
Add distribution automation for Copilot CLI feature

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish Dev Container Features
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive namespace
+        id: namespace
+        run: |
+          collection="${GITHUB_REPOSITORY}"
+          namespace="$(echo "${collection}" | tr '[:upper:]' '[:lower:]')"
+          echo "namespace=${namespace}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Feature Collection to GHCR
+        uses: devcontainers/action@v1
+        with:
+          publish-features: "true"
+          base-path-to-features: "./src"
+          oci-registry: "ghcr.io"
+          features-namespace: "${{ steps.namespace.outputs.namespace }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# Devvvcontainer-feature-ghcopilotcli
+# GitHub Copilot CLI Dev Container Feature
+
+This repository packages a Dev Container Feature that installs and configures the [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli) inside VS Code Dev Containers and GitHub Codespaces.
+
+## Contents
+
+- `src/copilot-cli`: Feature implementation (`devcontainer-feature.json`, install script, documentation).
+- `test/`: Automated tests using the Dev Container Features test harness.
+- `examples/`: Sample `devcontainer.json` configurations.
+
+## Getting started
+
+1. Build the feature locally:
+   ```bash
+   devcontainer features build src/copilot-cli
+   ```
+2. Run tests:
+   ```bash
+   devcontainer features test src/copilot-cli
+   ```
+3. Publish to a registry once you're satisfied (for example GitHub Container Registry):
+   ```bash
+   devcontainer features publish src/copilot-cli --namespace your-org/features
+   ```
+
+## Distribution
+
+- **GitHub Actions workflow** – `.github/workflows/publish.yml` publishes the feature collection to `ghcr.io` whenever you push a semantic tag (for example `v0.1.0`) or trigger the workflow manually.
+- **Local helper script** – `distribution/local-ubuntu-docker.sh` replicates the automated publish process on an Ubuntu host with Docker installed. It runs the Dev Containers CLI from a container so no additional tooling is required on the host.
+
+See `src/copilot-cli/README.md` for feature usage details and options.

--- a/dev-container-features-test-lib
+++ b/dev-container-features-test-lib
@@ -1,0 +1,3 @@
+#!/bin/bash
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test/_global/dev-container-features-test-lib"

--- a/distribution/local-ubuntu-docker.sh
+++ b/distribution/local-ubuntu-docker.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper script to publish the Feature collection from an Ubuntu host with Docker.
+# It mirrors the GitHub Actions workflow but runs locally using the devcontainers
+# CLI container image so no additional dependencies are required on the host.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REGISTRY_HOST="${REGISTRY_HOST:-ghcr.io}"
+
+# Attempt to detect the default namespace from the git remote (owner/repo).
+DEFAULT_NAMESPACE="local/features"
+if command -v git >/dev/null 2>&1; then
+  if origin_url=$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null); then
+    stripped="${origin_url%.git}"
+    stripped="${stripped#git@}"
+    stripped="${stripped#https://}"
+    stripped="${stripped#http://}"
+    stripped="${stripped#github.com/}"
+    stripped="${stripped#github.com:}"
+    if [[ "${stripped}" == */* ]]; then
+      DEFAULT_NAMESPACE="${stripped}"
+    fi
+  fi
+fi
+
+FEATURES_NAMESPACE="${FEATURES_NAMESPACE:-${DEFAULT_NAMESPACE}}"
+FEATURES_NAMESPACE="$(echo "${FEATURES_NAMESPACE}" | tr '[:upper:]' '[:lower:]')"
+COLLECTION="${COLLECTION:-${FEATURES_NAMESPACE}}"
+OCI_REF="${REGISTRY_HOST}/${COLLECTION}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to run this script." >&2
+  exit 1
+fi
+
+if [ "${REGISTRY_HOST}" != "localhost" ]; then
+  cat <<EOF1
+[info] Pushing to ${REGISTRY_HOST}. Ensure you have run 'docker login ${REGISTRY_HOST}'
+      (or 'gh auth login --scopes write:packages') before executing this script.
+EOF1
+fi
+
+# Use the devcontainers CLI container to publish the Features.
+docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "${REPO_ROOT}:/workspaces/repo" \
+  -w /workspaces/repo \
+  ghcr.io/devcontainers/ci:latest \
+  devcontainer features publish \
+    --registry "${REGISTRY_HOST}" \
+    --namespace "${FEATURES_NAMESPACE}" \
+    --base-path ./src
+
+cat <<EOF2
+Successfully published feature collection to ${OCI_REF}.
+Remember to adjust package visibility in GHCR if you want the Features to be public.
+EOF2

--- a/examples/basic/devcontainer.json
+++ b/examples/basic/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Copilot CLI Feature Example",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "features": {
+    "ghcr.io/your-org/features/copilot-cli:0.1.0": {
+      "version": "latest",
+      "installCompletions": true,
+      "withGH": true,
+      "autoUpdate": false
+    }
+  },
+  "postCreateCommand": "copilot --version"
+}

--- a/src/copilot-cli/README.md
+++ b/src/copilot-cli/README.md
@@ -1,0 +1,87 @@
+# GitHub Copilot CLI Feature
+
+This Dev Container Feature installs the [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli) so you can use Copilot agents directly from your terminal inside VS Code Dev Containers and GitHub Codespaces. The feature ensures the CLI binary is available for root and non-root users, installs the required Node.js runtime, and (optionally) brings in the GitHub CLI to simplify authentication workflows.
+
+## Installed components
+
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli) (`copilot` binary from the `@github/copilot` npm package)
+- Node.js 22.x runtime and npm 10+
+- Optional: GitHub CLI (`gh`) when `withGH=true`
+- Optional: shell completions for bash and zsh (when supported by the CLI)
+
+## Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `version` | string | `"latest"` | Install a specific npm release of `@github/copilot` (for example `"0.0.328"`). The special value `latest` installs the newest release if the CLI is not already present. |
+| `installCompletions` | boolean | `true` | Attempt to generate and install bash/zsh completions when supported by the CLI. If completions are not yet available, the feature logs and continues. |
+| `withGH` | boolean | `true` | Ensure the GitHub CLI is installed. If the platform does not provide packages (for example some Alpine images), a warning is emitted and installation continues. |
+| `autoUpdate` | boolean | `false` | When `version=latest`, automatically update to the most recent release on every rebuild. When `false`, the feature is idempotent and will leave the installed version untouched. |
+
+## Usage
+
+Add the feature to your `devcontainer.json` or `devcontainer-feature.json`:
+
+```jsonc
+{
+  "features": {
+    "./src/copilot-cli": {
+      "version": "latest",
+      "installCompletions": true,
+      "withGH": true,
+      "autoUpdate": false
+    }
+  }
+}
+```
+
+After the container rebuilds, verify the installation as any user inside the environment:
+
+```bash
+copilot --version
+copilot --help
+which copilot
+```
+
+## Authentication
+
+1. **Sign in with the GitHub CLI (recommended)**
+   - Run `gh auth login --web` or `gh auth login --device` inside the container.
+   - Enable the Copilot scopes when prompted, or ensure your existing token includes Copilot access.
+2. **Authenticate inside Copilot CLI**
+   - Launch the CLI with `copilot` and run `/login` when prompted.
+   - Follow the on-screen device code or paste a fine-grained PAT with the "Copilot Requests" permission enabled.
+
+### Codespaces specifics
+
+- Codespaces already provisions the GitHub CLI. With `withGH=true`, the feature simply verifies that `gh` is available.
+- Device-code authentication opens in your local browser. When using Codespaces in the browser, the device flow automatically opens a new tab. When using the VS Code desktop client, copy the URL/code as instructed.
+
+### Local Dev Containers
+
+- Ensure your host browser can reach `github.com/login/device`. For corporate proxies, configure the container-wide `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` variables before building.
+- If you rely on enterprise-issued CA certificates, install them via the base image or another feature so that Node.js and the GitHub CLI trust your MITM proxy.
+
+## Completions
+
+When `installCompletions=true`, the feature attempts to generate completions using `copilot help completion --shell <bash|zsh>` and places them in `/etc/bash_completion.d/copilot` and `/usr/local/share/zsh/site-functions/_copilot`. If the CLI does not yet expose a completion helper, the script logs a message and continues without failing.
+
+## Auto-updates and idempotency
+
+- By default, the feature installs Copilot CLI only once. Subsequent rebuilds keep the existing version to avoid unexpected behavior changes.
+- Set `autoUpdate=true` to refresh to the newest release on every rebuild when `version=latest`.
+- To pin a release, set `version` to an explicit npm version string.
+
+## Troubleshooting
+
+| Symptom | Possible fix |
+| ------- | ------------- |
+| `copilot` command missing | Ensure the feature completed successfully and `/usr/local/bin` is on `PATH`. Rebuild the container to retry. |
+| Network or proxy errors during install | Configure `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. Verify the proxy trusts GitHub domains and Node.js download hosts. |
+| Authentication loops | Verify your GitHub account has an active Copilot subscription and the feature policy allows the CLI. Check Copilot organization policies if applicable. |
+| GitHub CLI installation warning on Alpine | Alpine repositories may not contain `github-cli`. Install it manually from a compatible source or set `withGH=false`. |
+
+## References
+
+- [Use the GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- [github/copilot-cli repository](https://github.com/github/copilot-cli)

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,0 +1,35 @@
+{
+  "id": "copilot-cli",
+  "name": "copilot-cli",
+  "version": "0.1.0",
+  "description": "Installs and configures GitHub Copilot CLI",
+  "documentationURL": "https://github.com/github/copilot-cli",
+  "options": {
+    "version": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of @github/copilot npm package to install. Use \"latest\" for the newest release."
+    },
+    "installCompletions": {
+      "type": "boolean",
+      "default": true,
+      "description": "Attempt to install shell completions if supported by Copilot CLI."
+    },
+    "withGH": {
+      "type": "boolean",
+      "default": true,
+      "description": "Ensure GitHub CLI (gh) is installed to streamline authentication workflows."
+    },
+    "autoUpdate": {
+      "type": "boolean",
+      "default": false,
+      "description": "Update Copilot CLI to the latest version on rebuild when version=latest."
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils",
+    "ghcr.io/devcontainers/features/git",
+    "ghcr.io/devcontainers/features/github-cli",
+    "ghcr.io/devcontainers/features/node"
+  ]
+}

--- a/src/copilot-cli/install.sh
+++ b/src/copilot-cli/install.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION=${VERSION:-latest}
+INSTALL_COMPLETIONS=${INSTALLCOMPLETIONS:-true}
+WITH_GH=${WITHGH:-true}
+AUTO_UPDATE=${AUTOUPDATE:-false}
+
+PKG_MANAGER=""
+
+NODE_VERSION="22.11.0"
+NODE_DIST_URL="https://nodejs.org/dist/v${NODE_VERSION}"
+NODE_INSTALL_DIR="/usr/local/lib/nodejs"
+NPM_GLOBAL_PREFIX="/usr/local"
+
+log() {
+    echo "[copilot-cli] $1"
+}
+
+err() {
+    echo "[copilot-cli] ERROR: $1" >&2
+}
+
+run_as_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        err "This script must be run as root."
+        exit 1
+    fi
+}
+
+ensure_packages() {
+    if command -v apt-get >/dev/null 2>&1; then
+        PKG_MANAGER="apt"
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y --no-install-recommends ca-certificates curl tar xz-utils gnupg procps
+    elif command -v dnf >/dev/null 2>&1; then
+        PKG_MANAGER="dnf"
+        dnf -y install ca-certificates curl tar xz procps-ng coreutils gnupg2
+    elif command -v yum >/dev/null 2>&1; then
+        PKG_MANAGER="yum"
+        yum -y install ca-certificates curl tar xz procps-ng coreutils gnupg2
+    elif command -v apk >/dev/null 2>&1; then
+        PKG_MANAGER="apk"
+        apk update
+        apk add --no-cache ca-certificates curl tar xz coreutils bash
+    else
+        err "Unsupported package manager."
+        exit 1
+    fi
+}
+
+ensure_node() {
+    if command -v node >/dev/null 2>&1; then
+        local current
+        current=$(node -v | sed 's/^v//')
+        if printf '%s
+%s' "22.0.0" "${current}" | sort -V | tail -n 1 | grep -qx "${current}"; then
+            log "Node.js ${current} already present; skipping install."
+            return
+        else
+            log "Existing Node.js ${current} is older than required v22.x; upgrading."
+        fi
+    fi
+
+    if [ "${PKG_MANAGER}" = "apk" ]; then
+        apk add --no-cache nodejs-current npm
+        local current
+        current=$(node -v | sed 's/^v//')
+        if ! printf '%s\n%s' "22.0.0" "${current}" | sort -V | tail -n 1 | grep -qx "${current}"; then
+            err "Alpine repositories did not provide Node.js v22+."
+            exit 1
+        fi
+        log "Using Node.js ${current} from Alpine repositories."
+        return
+    fi
+
+    local arch
+    arch=$(uname -m)
+    local node_arch
+    case "$arch" in
+        x86_64|amd64)
+            node_arch="x64"
+            ;;
+        aarch64|arm64)
+            node_arch="arm64"
+            ;;
+        *)
+            err "Unsupported architecture: $arch"
+            exit 1
+            ;;
+    esac
+
+    mkdir -p "${NODE_INSTALL_DIR}"
+    local node_tar="node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"
+    local url="${NODE_DIST_URL}/${node_tar}"
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    curl -fsSL "${url}" -o "${tmp_dir}/${node_tar}"
+    tar -xJf "${tmp_dir}/${node_tar}" -C "${NODE_INSTALL_DIR}"
+    rm -rf "${tmp_dir}"
+
+    ln -sf "${NODE_INSTALL_DIR}/node-v${NODE_VERSION}-linux-${node_arch}/bin/node" /usr/local/bin/node
+    ln -sf "${NODE_INSTALL_DIR}/node-v${NODE_VERSION}-linux-${node_arch}/bin/npm" /usr/local/bin/npm
+    ln -sf "${NODE_INSTALL_DIR}/node-v${NODE_VERSION}-linux-${node_arch}/bin/npx" /usr/local/bin/npx
+    log "Installed Node.js v${NODE_VERSION} (${node_arch})."
+}
+
+install_gh_cli() {
+    if [ "${WITH_GH}" != "true" ]; then
+        log "Skipping GitHub CLI installation (withGH=${WITH_GH})."
+        return
+    fi
+
+    if command -v gh >/dev/null 2>&1; then
+        log "GitHub CLI already installed."
+        return
+    fi
+
+    if command -v apt-get >/dev/null 2>&1; then
+        if [ ! -f /usr/share/keyrings/githubcli-archive-keyring.gpg ]; then
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        fi
+        local arch
+        arch=$(dpkg --print-architecture)
+        echo "deb [arch=${arch} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" >/etc/apt/sources.list.d/github-cli.list
+        apt-get update
+        apt-get install -y --no-install-recommends gh
+    elif command -v dnf >/dev/null 2>&1; then
+        rpm --import https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        cat <<'REPO' >/etc/yum.repos.d/github-cli.repo
+[github-cli]
+name=GitHub CLI
+baseurl=https://cli.github.com/packages/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://cli.github.com/packages/githubcli-archive-keyring.gpg
+REPO
+        dnf install -y gh
+    elif command -v yum >/dev/null 2>&1; then
+        rpm --import https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        cat <<'REPO' >/etc/yum.repos.d/github-cli.repo
+[github-cli]
+name=GitHub CLI
+baseurl=https://cli.github.com/packages/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://cli.github.com/packages/githubcli-archive-keyring.gpg
+REPO
+        yum install -y gh
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache github-cli || log "Unable to install GitHub CLI from apk repository; continuing without it."
+    else
+        log "Unable to install GitHub CLI on this platform."
+    fi
+}
+
+ensure_npm_prefix() {
+    npm config set prefix "${NPM_GLOBAL_PREFIX}" >/dev/null 2>&1 || true
+    export NPM_CONFIG_PREFIX="${NPM_GLOBAL_PREFIX}"
+}
+
+install_copilot_cli() {
+    local installed_version=""
+    if command -v copilot >/dev/null 2>&1; then
+        installed_version=$(copilot --version 2>/dev/null | head -n 1 | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
+        if [ -z "${installed_version}" ]; then
+            installed_version=$(copilot --version 2>/dev/null | head -n 1 | sed -n 's/^copilot\/\([0-9][^ ]*\).*$/\1/p')
+        fi
+    fi
+    if [ -z "${installed_version}" ]; then
+        # Fallback via npm list if binary missing but package installed
+        installed_version=$(npm list -g @github/copilot --depth=0 2>/dev/null | grep -o '@[0-9][^ ]*' | sed 's/@//' | tail -n 1 || true)
+    fi
+
+    local target="${VERSION}"
+    local install_arg="@github/copilot"
+    if [ "${target}" != "latest" ]; then
+        install_arg="@github/copilot@${target}"
+    fi
+
+    if [ -n "${installed_version}" ]; then
+        if [ "${target}" = "latest" ] && [ "${AUTO_UPDATE}" != "true" ]; then
+            log "Copilot CLI ${installed_version} already installed; skipping update (autoUpdate=false)."
+            return
+        fi
+        if [ "${target}" != "latest" ] && [ "${installed_version}" = "${target}" ]; then
+            log "Copilot CLI ${installed_version} already matches requested version."
+            return
+        fi
+    elif [ "${target}" = "latest" ]; then
+        log "Copilot CLI not found; installing latest release."
+    else
+        log "Copilot CLI not found; installing version ${target}."
+    fi
+
+    npm install -g "${install_arg}"
+}
+
+setup_completions() {
+    if [ "${INSTALL_COMPLETIONS}" != "true" ]; then
+        log "Skipping completions setup (installCompletions=${INSTALL_COMPLETIONS})."
+        return
+    fi
+
+    if ! command -v copilot >/dev/null 2>&1; then
+        log "Copilot CLI not available for completions setup."
+        return
+    fi
+
+    if copilot help completion >/dev/null 2>&1; then
+        local bash_dir="/etc/bash_completion.d"
+        local zsh_dir="/usr/local/share/zsh/site-functions"
+        mkdir -p "${bash_dir}" "${zsh_dir}"
+        copilot help completion --shell bash >/etc/bash_completion.d/copilot
+        copilot help completion --shell zsh >"${zsh_dir}/_copilot"
+        log "Installed Copilot CLI completions for bash and zsh."
+    else
+        log "Copilot CLI does not expose completion helpers; skipping."
+    fi
+}
+
+cleanup() {
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf clean all || true
+        rm -rf /var/cache/dnf
+    elif command -v yum >/dev/null 2>&1; then
+        yum clean all || true
+        rm -rf /var/cache/yum
+    elif command -v apk >/dev/null 2>&1; then
+        rm -rf /var/cache/apk/*
+    fi
+}
+
+main() {
+    run_as_root
+    ensure_packages
+    ensure_node
+    ensure_npm_prefix
+    install_gh_cli
+    install_copilot_cli
+    setup_completions
+    cleanup
+    log "Installation complete."
+}
+
+main "$@"

--- a/test/_global/dev-container-features-test-lib
+++ b/test/_global/dev-container-features-test-lib
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+_TEST_RESULTS=()
+_TEST_FAIL=0
+
+check() {
+    local name="$1"
+    shift
+    if "$@" >/tmp/devcontainer-test-stdout 2>/tmp/devcontainer-test-stderr; then
+        echo "✔︎ ${name}"
+        _TEST_RESULTS+=("PASS:${name}")
+    else
+        echo "✘ ${name}" >&2
+        echo "STDOUT:" >&2
+        cat /tmp/devcontainer-test-stdout >&2 || true
+        echo "STDERR:" >&2
+        cat /tmp/devcontainer-test-stderr >&2 || true
+        _TEST_RESULTS+=("FAIL:${name}")
+        _TEST_FAIL=1
+    fi
+}
+
+reportResults() {
+    if [ "${_TEST_FAIL}" -ne 0 ]; then
+        echo "Test suite failed" >&2
+        exit 1
+    fi
+}

--- a/test/copilot-cli/scenarios.json
+++ b/test/copilot-cli/scenarios.json
@@ -1,0 +1,14 @@
+{
+  "debian": {
+    "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+    "features": {
+      "copilot-cli": {}
+    }
+  },
+  "fedora": {
+    "image": "mcr.microsoft.com/devcontainers/base:fedora-41",
+    "features": {
+      "copilot-cli": {}
+    }
+  }
+}

--- a/test/copilot-cli/test.sh
+++ b/test/copilot-cli/test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+source dev-container-features-test-lib
+
+extract_version() {
+    local version
+    version=$(copilot --version | head -n 1 | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
+    if [ -z "${version}" ]; then
+        version=$(copilot --version | head -n 1 | sed -n 's/^copilot\/\([0-9][^ ]*\).*$/\1/p')
+    fi
+    echo "${version}"
+}
+
+check "copilot on PATH" which copilot
+check "copilot version" copilot --version
+check "copilot help" copilot --help
+
+INSTALLED_VERSION=$(extract_version)
+
+check "copilot binary is executable" test -x "$(command -v copilot)"
+
+if [ -n "${INSTALLED_VERSION}" ]; then
+    check "idempotent reinstall" bash -lc "npm install -g @github/copilot@${INSTALLED_VERSION} && copilot --version | grep -F \"${INSTALLED_VERSION}\""
+else
+    echo "Unable to determine installed Copilot CLI version" >&2
+    exit 1
+fi
+
+reportResults


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that publishes the feature collection to ghcr.io using the devcontainers/action
- document the distribution paths and provide a helper script for publishing from an Ubuntu host with Docker
- rename the feature metadata file to `devcontainer-feature.json` so validation succeeds during publication

## Testing
- `devcontainer features test --project-folder . --filter copilot-cli` *(fails: Docker daemon unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d927355a54832893807a3219096993